### PR TITLE
Fixed wordpress service repository

### DIFF
--- a/services/wordpress/app.yaml
+++ b/services/wordpress/app.yaml
@@ -6,7 +6,7 @@ spec:
   name: wordpress
   deploymentstrategy: docker
   image:
-    repository: zadam/trilium
+    repository: bitnami/wordpress
     tag: latest
     containerPort: "8080"
   addons:


### PR DESCRIPTION
Changed from zadam/trilium to bitnami/wordpress